### PR TITLE
Test reorganisation & travis ci integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+# See http://about.travis-ci.org/docs/user/languages/ruby/
+language: ruby
+rvm:
+  - 1.8.7
+  - 1.9.3
+  - jruby-19mode
+

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,9 @@
 #!/usr/bin/env rake
-require "bundler/gem_tasks"
+require 'bundler/gem_tasks'
+require 'rake/testtask'
+
+task :default => :test
+Rake::TestTask.new(:test) do |t|
+  t.test_files = Dir.glob('*_test.rb')
+  t.verbose = true
+end

--- a/inflections.gemspec
+++ b/inflections.gemspec
@@ -9,12 +9,12 @@ Gem::Specification.new do |gem|
   gem.homepage      = 'https://github.com/davidcelis/inflections'
 
   gem.files         = `git ls-files`.split($\)
-  gem.test_files    = ['inflections_test.rb']
+  gem.test_files    = `git ls-files -- *_test.rb`.split($\)
   gem.name          = 'inflections'
   gem.require_paths = ['lib']
   gem.version       = Inflections::VERSION
 
-  gem.add_development_dependency 'bundler'
+  gem.add_development_dependency 'rake'
   gem.add_development_dependency 'minitest'
 
   gem.add_dependency 'activesupport', '>= 2.2.1'

--- a/inflections_test.rb
+++ b/inflections_test.rb
@@ -1,5 +1,6 @@
-require 'inflections'
+require 'bundler/setup'
 require 'minitest/autorun'
+require 'inflections'
 
 class TestInflections < MiniTest::Unit::TestCase
   def test_regular_plurals


### PR DESCRIPTION
All right here's a first pull request to handle slightly reorganize your tests and add support for travis-ci.org
- changed Rakefile to include default task and test task (so travis can easily run `rake`)
- changed gemspec to include rake (otherwise travis doesnt work)
- removed bundler from gemspec, because this is an implicit dependency
- moved tests to `test/` directory
- added simple test_helper so tests can be run standalone `ruby -Ilib:test test/name_of_test.rb`
