### PR TITLE
Words ending with e => es (conflicts with existing rule)

### DIFF
--- a/test/es_test.rb
+++ b/test/es_test.rb
@@ -32,4 +32,10 @@ class TestSpanishInflections < MiniTest::Unit::TestCase
     assert_equal 'los', 'el'.pluralize(:es)
     assert_equal 'el', 'los'.singularize(:es)
   end
+
+  def test_palabras_terminadas_en_e
+    assert_equal 'fase', 'fases'.singularize(:es)
+    assert_equal 'clase', 'clases'.singularize(:es)
+    assert_equal 'serie', 'series'.singularize(:es)
+  end
 end

--- a/test/es_test.rb
+++ b/test/es_test.rb
@@ -34,6 +34,7 @@ class TestSpanishInflections < MiniTest::Unit::TestCase
   end
 
   def test_palabras_terminadas_en_e
+    assert_equal 'pasaje', 'pasajes'.singularize(:es)
     assert_equal 'fase', 'fases'.singularize(:es)
     assert_equal 'clase', 'clases'.singularize(:es)
     assert_equal 'serie', 'series'.singularize(:es)


### PR DESCRIPTION
What do you think about these cases? I don't know how, or if it's possible, to prepare a rule for them, so I'm just submitting the failing test.

    test_palabras_terminadas_en_e(TestSpanishInflections) [/inflections/test/es_test.rb:37]:
    Expected: "pasaje"
      Actual: "pasaj"

I'm ok with specifing those in the application inflections initializer, but just in case there is a common rule out there..