### PR TITLE
Add preliminary Latin (LA) support

### DIFF
--- a/lib/inflections/la.rb
+++ b/lib/inflections/la.rb
@@ -1,0 +1,29 @@
+# encoding: UTF-8
+module Inflections
+  ActiveSupport::Inflector.inflections(:la) do |inflect|
+    inflect.clear
+
+    # First declension
+    inflect.plural(/a$/, 'ae')
+
+    # Second
+    inflect.plural(/us$/, 'i')
+    inflect.plural(/(.*)([^aeiou])e(r)/, '\1\2\3es')
+    inflect.plural(/(.*)([aeiou])er$/, '\1\2eri')
+    inflect.plural(/um$/, 'a')
+
+    # Fourth
+    inflect.plural(/u$/, 'ua')
+    inflect.plural(/(curs)(us)/, '\1ūs')
+
+    # Fifth
+    inflect.plural(/es$/, 'es')
+
+    # Third declension is a catch-all given irregularity in
+    # nominative case
+    #
+    # TODO:  How to handle something that requires knowledge
+    # about the genitive to work?
+    inflect.plural(/nomen/, 'nomina')
+  end
+end

--- a/test/la_test.rb
+++ b/test/la_test.rb
@@ -1,0 +1,38 @@
+# encoding: UTF-8
+require 'test_helper'
+require 'inflections/la'
+
+class TestLatinInflections < MiniTest::Unit::TestCase
+  def test_first_declension
+    assert_equal 'poetae', 'poeta'.pluralize(:la)
+  end
+
+  def test_second_declension_masculine
+    assert_equal 'somni', 'somnus'.pluralize(:la)
+  end
+
+  def test_second_declension_neuter
+    assert_equal 'dona', 'donum'.pluralize(:la)
+  end
+
+  def test_third_declension_gendered
+    assert_equal 'patres', 'pater'.pluralize(:la)
+    assert_equal 'pueri', 'puer'.pluralize(:la)
+  end
+
+  def test_third_declension_neuter
+    assert_equal 'nomina', 'nomen'.pluralize(:la)
+  end
+
+  def test_fourth_declension_gendered
+    assert_equal 'cursūs', 'cursus'.pluralize(:la)
+  end
+
+  def test_fourth_declension_neuter
+    assert_equal 'cornua', 'cornu'.pluralize(:la)
+  end
+
+  def test_fifth_declension
+    assert_equal 'res', 'res'.pluralize(:la)
+  end
+end


### PR DESCRIPTION
Known issues surround ambiguity based on the
subjective case.  Latin uses the subjective _AND_
genitive cases to know which form a noun takes.
`ActiveSupport::Inflector` assumes this is
knowable solely based on the subjective case.
Consequently in cases of ambiguity, where the
genitive case would decide the issue, we come up
with these problems:
# First

`/us$/` (2nd decl, masc) versus `/us$/` (4th decl,
genderd)
# Second

Third declension nouns -- all of them where we can't
know from the subjective case what base to use.
How to handle that both 'arx' and 'corpus' should
fall here?

Nevertheless, we do make a step forward in this
commit.
