### PR TITLE
Fix Brazilian Portuguese locale key

### DIFF
--- a/lib/inflections/pt-BR.rb
+++ b/lib/inflections/pt-BR.rb
@@ -10,7 +10,7 @@
 #   inflect.uncountable %w( fish sheep )
 # end
 module Inflections
-  ActiveSupport::Inflector.inflections(:pt_br) do |inflect|
+  ActiveSupport::Inflector.inflections(:'pt_BR') do |inflect|
     inflect.clear
 
     inflect.plural(/$/,  's')


### PR DESCRIPTION
This inflection only seems to work if I set it as the correct symbol.
